### PR TITLE
Remove unnecessary assert in next_vector

### DIFF
--- a/src/iters.rs
+++ b/src/iters.rs
@@ -217,7 +217,7 @@ impl<'a, T> PackedIterator for PackedIter<'a, T> where T : Packable {
     #[inline(always)]
     fn next_vector(&mut self) -> Option<Self::Vector> {
         if self.position + self.width() <= self.scalar_len() {
-            let ret = Some(Self::Vector::load(self.data, self.position));
+            let ret = unsafe{ Some(Self::Vector::load_unchecked(self.data, self.position))};
             self.position += Self::Vector::WIDTH;
             ret
         } else {

--- a/src/vecs.rs
+++ b/src/vecs.rs
@@ -31,6 +31,10 @@ pub trait Packed : Sized + Copy + Debug + PackedMerge {
     /// at `offset`.
     fn load(data: &[Self::Scalar], offset: usize) -> Self;
 
+    /// Create a new vector with `Self::WIDTH` elements from `data`, beginning
+    /// at `offset`, without asserting length of data.
+    unsafe fn load_unchecked(data: &[Self::Scalar], offset: usize) -> Self;
+
     /// Write `Self::WIDTH` elements from this vector to `data`, beginning at
     /// `offset`.
     fn store(self, data: &mut [Self::Scalar], offset: usize);
@@ -101,6 +105,11 @@ macro_rules! impl_packed {
             #[inline(always)]
             fn load(data: &[$el], offset: usize) -> $vec {
                 $vec::load(data, offset)
+            }
+
+            #[inline(always)]
+            unsafe fn load_unchecked(data: &[$el], offset: usize) -> $vec {
+                $vec::load_unchecked(data, offset)
             }
 
             #[inline(always)]


### PR DESCRIPTION
First thing that happens in `next_vector` function is check if there is enough elements in data to do the load to simd vector, but it seems that the compiler is not able to remove assert from load function. So I have changed it to load_unchecked. The only benchmark available in this crate that is affected is:
` tests::bench_nop_simd             144             88                      -56  -38.89%   x 1.64`
but my application that goes over much bigger collection than this used in benchmarks speeds up from 14 to 12 seconds.