### PR TITLE
Don't use types as traits in macros

### DIFF
--- a/src/intrin/cast.rs
+++ b/src/intrin/cast.rs
@@ -8,7 +8,7 @@
 use vecs::{u8x64, u8x32, u8x16, i8x64, i8x32, i8x16, u16x32, u16x16, u16x8, i16x32, i16x16, i16x8, u32x16, u32x8, u32x4, i32x16, i32x8, i32x4, f32x16, f32x8, f32x4, u64x8, u64x4, u64x2, i64x8, i64x4, i64x2, f64x8, f64x4, f64x2};
 
 macro_rules! impl_cast {
-    ($trait:ty, $from:ty, $to:ty, $name:ident, $rsname:ident) => (
+    ($trait:path, $from:ty, $to:ty, $name:ident, $rsname:ident) => (
         impl $trait for $from {
             type Cast = $to;
 


### PR DESCRIPTION
Hello.

We've found that this crate is affected by an upcoming bugfix in `rustc` - https://github.com/rust-lang/rust/pull/48502 (`ty` fragments are no longer accepted as traits in trait impls).
This PR fixes the deprecated use of `ty`.