### PR TITLE
Make the striding iterator clonable

### DIFF
--- a/src/iters.rs
+++ b/src/iters.rs
@@ -191,7 +191,7 @@ pub trait SIMDArrayMut : SIMDArray {
 
 /// A slice-backed iterator which can automatically pack its constituent
 /// elements into vectors.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SIMDIter<A : SIMDArray> {
     pub position: usize,
     pub data: A,

--- a/src/stride.rs
+++ b/src/stride.rs
@@ -19,6 +19,7 @@ use intrin::Transmute;
 
 /// A slice-backed iterator which packs every nth element of its constituent
 /// elements into a vector.
+#[derive(Clone)]
 pub struct PackedStride<'a, A> where A : 'a + SIMDArray {
     iter: &'a A,
     pos: usize,


### PR DESCRIPTION
It's sometimes expensive to build them (because a Vec is allocated for
it), so it makes sense to reuse them.

I discovered this when I wanted to write matrix multiplication (for arbitrary matrix sizes) ‒ I had to do a strided iterators for the columns, but they were for single use. Because the `stride` returns a `Vec`, it needs to be allocated every time, which is expensive ‒ it's cheaper to clone the iterators themselves.

Or, would it make sense derive clone for some more iterator types as well?