### PR TITLE
Fix count_zeroes and optimized count_ones

### DIFF
--- a/src/arch/x86/intrin/popcnt.rs
+++ b/src/arch/x86/intrin/popcnt.rs
@@ -23,9 +23,10 @@ unsafe fn popcnt128(v: u8x16) -> usize {
     // http://wm.ite.pl/articles/sse-popcount.html
     optimized!();
     let lookup = i8x16::new(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
-    let lo = v.be_i8s() & i8x16::splat(0x0f);
-    let hi = v.be_i8s() >> 4 & i8x16::splat(0x0f);
-    (_mm_shuffle_epi8(lookup, hi) + _mm_shuffle_epi8(lookup, lo))
+    let lo = v.be_u8s() & 0x0f;
+    let hi: u8x16 = v.be_u8s() >> 4;
+    (_mm_shuffle_epi8(lookup, hi.be_i8s()).be_u8s()
+        + _mm_shuffle_epi8(lookup, lo.be_i8s()).be_u8s())
         .sum_upcast() as usize
 }
 
@@ -45,9 +46,10 @@ unsafe fn popcnt256(v: u8x32) -> usize {
     optimized!();
     let lookup = i8x32::new(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
                             0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
-    let lo = v.be_i8s() & i8x32::splat(0x0f);
-    let hi = (v.be_i8s() >> 4) & i8x32::splat(0x0f);
-    (_mm256_shuffle_epi8(lookup, hi) + _mm256_shuffle_epi8(lookup, lo))
+    let lo = v.be_u8s() & 0x0f;
+    let hi: u8x32 = v.be_u8s() >> 4;
+    (_mm256_shuffle_epi8(lookup, hi.be_i8s()).be_u8s()
+        + _mm256_shuffle_epi8(lookup, lo.be_i8s()).be_u8s())
         .sum_upcast() as usize
 }
 

--- a/src/intrin/popcnt.rs
+++ b/src/intrin/popcnt.rs
@@ -44,6 +44,9 @@ macro_rules! test_popcnt {
                 assert_eq!($vec::splat(1i8 as $el).count_zeroes()
                            + $vec::splat(1i8 as $el).count_ones(),
                            $vec::WIDTH * <<$vec as Packed>::Scalar as Packable>::SIZE * 8);
+                assert_eq!($vec::splat(!(0 as $el)).count_ones(),
+                           $vec::WIDTH * <<$vec as Packed>::Scalar as Packable>::SIZE * 8);
+                assert_eq!($vec::splat(!(0 as $el)).count_zeroes(), 0);
             }
         )*
     )

--- a/src/intrin/popcnt.rs
+++ b/src/intrin/popcnt.rs
@@ -12,7 +12,7 @@ pub trait Popcnt : Packed {
 
     #[inline(always)]
     fn count_zeroes(&self) -> usize {
-        (Self::WIDTH * Self::Scalar::SIZE) - self.count_ones()
+        (Self::WIDTH * Self::Scalar::SIZE * 8) - self.count_ones()
     }
 }
 
@@ -43,7 +43,7 @@ macro_rules! test_popcnt {
                 assert_eq!($vec::splat(1i8 as $el).count_ones(), $vec::WIDTH);
                 assert_eq!($vec::splat(1i8 as $el).count_zeroes()
                            + $vec::splat(1i8 as $el).count_ones(),
-                           $vec::WIDTH * <<$vec as Packed>::Scalar as Packable>::SIZE);
+                           $vec::WIDTH * <<$vec as Packed>::Scalar as Packable>::SIZE * 8);
             }
         )*
     )


### PR DESCRIPTION
Use the size in bits, not bytes, in `count_zeroes`; use unsigned arithmetic in optimized `count_ones`. Fixes #54.