### PR TITLE
Fix on latest nightly by switching from std::simd to packed_simd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.org"
 
 [dependencies]
 vektor = "0.2.0"
+packed_simd = "0.3"
 
 [features]
 default = ["std"]

--- a/src/arch/unknown/intrin/abs.rs
+++ b/src/arch/unknown/intrin/abs.rs
@@ -7,7 +7,7 @@
 
 use crate::intrin::abs::Abs;
 use crate::arch::current::vecs::*;
-use crate::std::mem::transmute;
+use crate::core::mem::transmute;
 
 impl Abs for f32x4 {
     type Out = f32x4;

--- a/src/arch/unknown/intrin/hadd.rs
+++ b/src/arch/unknown/intrin/hadd.rs
@@ -6,7 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::intrin::hadd::*;
-use crate::std::ops::Add;
+use crate::core::ops::Add;
 use crate::arch::current::vecs::*;
 use crate::vecs::*;
 

--- a/src/arch/unknown/intrin/hsub.rs
+++ b/src/arch/unknown/intrin/hsub.rs
@@ -8,7 +8,7 @@
 use crate::arch::current::vecs::*;
 use crate::vecs::*;
 use crate::intrin::hsub::*;
-use crate::std::ops::Sub;
+use crate::core::ops::Sub;
 
 impl HSub for u64x2 { hop!(hsub, Sub::sub, 0, 1); }
 impl HSub for u32x4 { hop!(hsub, Sub::sub, 0, 1, 2, 3); }

--- a/src/arch/unknown/intrin/transmute.rs
+++ b/src/arch/unknown/intrin/transmute.rs
@@ -7,7 +7,7 @@
 
 use crate::intrin::transmute::*;
 use crate::arch::current::vecs::*;
-use crate::std::mem::transmute;
+use crate::core::mem::transmute;
 
 impl_packed_transmute!(u8x16, i8x16, u16x8, i16x8, u32x4, i32x4, f32x4,
                        u64x2, i64x2, f64x2, ...

--- a/src/arch/unknown/vec_patterns.rs
+++ b/src/arch/unknown/vec_patterns.rs
@@ -12,7 +12,7 @@
 #![allow(unused_imports)]
 
 use crate::arch::current::vecs::*;
-use crate::std::mem::transmute;
+use crate::core::mem::transmute;
 use crate::vecs::*;
 
 

--- a/src/arch/unknown/vecs.rs
+++ b/src/arch/unknown/vecs.rs
@@ -9,10 +9,10 @@
 
 //! Vector types which aren't interpreted as SIMD vectors, for systems which
 //! don't have SIMD support.
-use crate::std::ops::*;
-use crate::std::mem::*;
-use crate::std::ptr::*;
-use crate::std::fmt::*;
+use crate::core::ops::*;
+use crate::core::mem::*;
+use crate::core::ptr::*;
+use crate::core::fmt::*;
 use crate::vecs::*;
 
 macro_rules! impl_packed_type {

--- a/src/arch/x86/intrin/abs.rs
+++ b/src/arch/x86/intrin/abs.rs
@@ -11,7 +11,7 @@ use crate::vektor::x86_64::*;
 use crate::vektor::x86::*;
 use crate::vektor::x86::*;
 use crate::arch::current::vecs::*;
-use crate::std::mem::transmute;
+use crate::core::mem::transmute;
 
 impl Abs for f32x4 {
     type Out = f32x4;

--- a/src/arch/x86/intrin/destride.rs
+++ b/src/arch/x86/intrin/destride.rs
@@ -5,7 +5,7 @@ use crate::vektor::x86::*;
 use crate::intrin::merge::*;
 use crate::intrin::transmute::*;
 use crate::intrin::destride::*;
-use crate::std::mem::transmute;
+use crate::core::mem::transmute;
 
 impl Destride for u8x16 {
     #[inline(always)]

--- a/src/arch/x86/intrin/downcast.rs
+++ b/src/arch/x86/intrin/downcast.rs
@@ -11,7 +11,7 @@ use crate::vektor::x86_64::*;
 use crate::vektor::x86::*;
 use crate::intrin::downcast::*;
 use crate::intrin::transmute::*;
-use crate::std::mem::transmute;
+use crate::core::mem::transmute;
 
 impl Downcast<i16x8> for i32x4 {
     #[inline(always)]

--- a/src/arch/x86/intrin/endian.rs
+++ b/src/arch/x86/intrin/endian.rs
@@ -4,7 +4,7 @@ use crate::vektor::x86_64::*;
 use crate::vektor::x86::*;
 use crate::intrin::endian::*;
 use crate::intrin::transmute::*;
-use crate::std::mem::transmute;
+use crate::core::mem::transmute;
 
 impl_packed_swap_bytes!(u8x64, u8x64, "avx512-butnotyet", _mm512_permutexvar_epi8,
                         (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63),

--- a/src/arch/x86/intrin/eq.rs
+++ b/src/arch/x86/intrin/eq.rs
@@ -7,7 +7,7 @@
 
 use crate::vektor::x86_64::*;
 use crate::vektor::x86::*;
-use crate::std::ops::BitXor;
+use crate::core::ops::BitXor;
 use crate::intrin::eq::*;
 use crate::arch::current::vecs::*;
 use crate::vecs::*;

--- a/src/arch/x86/intrin/hadd.rs
+++ b/src/arch/x86/intrin/hadd.rs
@@ -9,7 +9,7 @@ use crate::vektor::x86_64::*;
 use crate::vektor::x86::*;
 use crate::intrin::transmute::*;
 use crate::intrin::hadd::*;
-use crate::std::ops::Add;
+use crate::core::ops::Add;
 use crate::arch::current::vecs::*;
 use crate::vecs::*;
 

--- a/src/arch/x86/intrin/hsub.rs
+++ b/src/arch/x86/intrin/hsub.rs
@@ -11,7 +11,7 @@ use crate::arch::current::vecs::*;
 use crate::vecs::*;
 use crate::intrin::transmute::*;
 use crate::intrin::hsub::*;
-use crate::std::ops::Sub;
+use crate::core::ops::Sub;
 
 #[cfg(target_feature = "sse3")]
 impl HSub for f32x4 {

--- a/src/arch/x86/intrin/merge.rs
+++ b/src/arch/x86/intrin/merge.rs
@@ -5,7 +5,7 @@ use crate::vektor::x86_64::*;
 use crate::vektor::x86::*;
 use crate::intrin::transmute::*;
 use crate::intrin::merge::*;
-use crate::std::mem::transmute;
+use crate::core::mem::transmute;
 
 // TODO: The AVX-512 version of this macro doesn't work; impl when stdsimd gets
 // around to it (and when I have some hardware to test it on).

--- a/src/arch/x86/intrin/round.rs
+++ b/src/arch/x86/intrin/round.rs
@@ -8,7 +8,7 @@
 use crate::vektor::x86_64::*;
 use crate::vektor::x86::*;
 use crate::intrin::round::Round;
-use crate::std::arch::x86_64::{_MM_FROUND_TO_NEAREST_INT, _MM_FROUND_TRUNC};
+use crate::core::arch::x86_64::{_MM_FROUND_TO_NEAREST_INT, _MM_FROUND_TRUNC};
 use crate::arch::current::vecs::*;
 use crate::vecs::*;
 

--- a/src/arch/x86/intrin/sum.rs
+++ b/src/arch/x86/intrin/sum.rs
@@ -2,7 +2,7 @@ use crate::arch::current::vecs::*;
 use crate::vecs::*;
 use crate::vektor::x86_64::*;
 use crate::vektor::x86::*;
-use crate::std::ops::Add;
+use crate::core::ops::Add;
 use crate::intrin::upcast::Upcast;
 use crate::intrin::cmp::Cmp;
 use crate::intrin::abs::Abs;

--- a/src/arch/x86/intrin/swizzle.rs
+++ b/src/arch/x86/intrin/swizzle.rs
@@ -3,7 +3,7 @@ use crate::vecs::*;
 use crate::vektor::x86_64::*;
 use crate::vektor::x86::*;
 use crate::intrin::transmute::*;
-use crate::std::mem::transmute;
+use crate::core::mem::transmute;
 
 impl_packed_swizzle!(u8x64, u8x64, "avx512-butnotyet", _mm512_permutexvar_epi8,
                      (1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14, 17, 16, 19, 18, 21, 20, 23, 22, 25, 24, 27, 26, 29, 28, 31, 30, 33, 32, 35, 34, 37, 36, 39, 38, 41, 40, 43, 42, 45, 44, 47, 46, 49, 48, 51, 50, 53, 52, 55, 54, 57, 56, 59, 58, 61, 60, 63, 62),

--- a/src/arch/x86/intrin/transmute.rs
+++ b/src/arch/x86/intrin/transmute.rs
@@ -10,7 +10,7 @@ use crate::vektor::x86::*;
 use crate::intrin::transmute::*;
 use crate::arch::current::vecs::*;
 use crate::vecs::*;
-use crate::std::mem::transmute;
+use crate::core::mem::transmute;
 
 impl_packed_transmute!(u8x32, i8x32, u16x16, i16x16, u32x8, i32x8, f32x8,
                        u64x4, i64x4, f64x4, ...

--- a/src/arch/x86/intrin/upcast.rs
+++ b/src/arch/x86/intrin/upcast.rs
@@ -11,7 +11,7 @@ use crate::intrin::transmute::*;
 use crate::intrin::upcast::*;
 use crate::vektor::x86_64::*;
 use crate::vektor::x86::*;
-use crate::std::mem::transmute;
+use crate::core::mem::transmute;
 
 impl Upcast<u16x8> for u8x16 {
     #[inline(always)]

--- a/src/arch/x86/vec_patterns.rs
+++ b/src/arch/x86/vec_patterns.rs
@@ -12,7 +12,7 @@
 #![allow(unused_imports)]
 
 use crate::arch::current::vecs::*;
-use crate::std::mem::transmute;
+use crate::core::mem::transmute;
 use crate::vecs::*;
 
 use vektor::x86::*;

--- a/src/arch/x86/vecs.rs
+++ b/src/arch/x86/vecs.rs
@@ -1,5 +1,5 @@
 pub use crate::vecs::*;
-pub use crate::std::simd::{u8x64, u8x32, u8x16, i8x64, i8x32, i8x16, u16x32, u16x16, u16x8, i16x32, i16x16, i16x8, u32x16, u32x8, u32x4, i32x16, i32x8, i32x4, f32x16, f32x8, f32x4, u64x8, u64x4, u64x2, i64x8, i64x4, i64x2, f64x8, f64x4, f64x2};
+pub use packed_simd::{u8x64, u8x32, u8x16, i8x64, i8x32, i8x16, u16x32, u16x16, u16x8, i16x32, i16x16, i16x8, u32x16, u32x8, u32x4, i32x16, i32x8, i32x4, f32x16, f32x8, f32x4, u64x8, u64x4, u64x2, i64x8, i64x4, i64x2, f64x8, f64x4, f64x2};
 
 impl_packed!(u8, u8s, u8x64, 1, 64, ["avx512"], ["avx1024"]);
 impl_packed!(u8, u8s, u8x32, 1, 32, ["avx2"], ["avx512"]);

--- a/src/intrin/eq.rs
+++ b/src/intrin/eq.rs
@@ -5,7 +5,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::std::ops::BitXor;
+use crate::core::ops::BitXor;
 use crate::vecs::*;
 
 pub trait Eq : Packed {
@@ -53,7 +53,7 @@ macro_rules! rust_fallback_eq {
                 #[inline(always)]
                 #[cfg(target_feature = $feat)]
                 fn $newfn(&self, other: Self) -> $mask {
-                    use crate::std::mem::transmute;
+                    use crate::core::mem::transmute;
                     unsafe { transmute($mmfn(transmute(*self), transmute(other), $($mmfnargs),*)) }
                 }
 
@@ -61,7 +61,7 @@ macro_rules! rust_fallback_eq {
                 #[cfg(not(target_feature = $feat))]
                 fn $newfn(&self, other: Self) -> Self::Out {
                     fallback!();
-                    use crate::std::mem::transmute;
+                    use crate::core::mem::transmute;
                     unsafe {
                         Self::Out::new($(transmute(if self.extract($n).$rustfn(&other.extract($n)) {
                             $maskel::max_value()

--- a/src/intrin/macros.rs
+++ b/src/intrin/macros.rs
@@ -37,7 +37,7 @@ macro_rules! rust_fallback_impl_binary {
                 #[inline(always)]
                 #[cfg(target_feature = $feat)]
                 fn $rustfn(&self, other: Self) -> Self {
-                    use crate::std::mem::transmute;
+                    use crate::core::mem::transmute;
                     optimized!();
                     unsafe { transmute($mmfn(transmute(*self), transmute(other), $($mmfnargs),*)) }
                 }

--- a/src/iters.rs
+++ b/src/iters.rs
@@ -6,7 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::vecs::{Packable, Packed};
-use crate::std::slice::from_raw_parts;
+use crate::core::slice::from_raw_parts;
 
 pub trait SIMDObject : Sized {
     type Scalar : Packable;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,13 +196,19 @@
 //! that these problems will crop up even if you only support x86; the width
 //! difference between AVX and SSE is the primary source of these issues!
 
-#![cfg_attr(feature = "no-std", no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(test, feature(test))]
 #![feature(rust_2018_preview, stdsimd)]
 // , mmx_target_feature, sse4a_target_feautre, tbm_target_feature
-#[cfg(not(feature = "std"))]
-pub use ::core as std;
 
+mod core {
+    #[cfg(not(feature = "std"))]
+    pub use core::*;
+    #[cfg(feature = "std")]
+    pub use std::*;
+}
+
+extern crate packed_simd;
 extern crate vektor;
 
 #[macro_use] pub(crate) mod debug;

--- a/src/stride.rs
+++ b/src/stride.rs
@@ -9,11 +9,11 @@
 
 use crate::arch::current::vecs::*;
 use crate::iters::{SIMDIterable, SIMDIterator, SIMDArray, SIMDObject, UnsafeIterator, SIMDSized};
-use crate::std::iter::{Iterator, ExactSizeIterator, FromIterator};
+use crate::core::iter::{Iterator, ExactSizeIterator, FromIterator};
 use crate::vecs::*;
 
 // For AVX2 gathers
-use crate::std::mem::transmute;
+use crate::core::mem::transmute;
 use crate::intrin::transmute::*;
 
 /// A slice-backed iterator which packs every nth element of its constituent

--- a/src/vecs.rs
+++ b/src/vecs.rs
@@ -7,7 +7,7 @@
 #![allow(dead_code)]
 
 pub use crate::vec_patterns::Pattern;
-use crate::std::fmt::Debug;
+use crate::core::fmt::Debug;
 use crate::intrin::merge::*;
 
 /// A SIMD vector of some type.
@@ -111,24 +111,24 @@ macro_rules! impl_packed {
 
             #[inline(always)]
             fn load(data: &[$el], offset: usize) -> $vec {
-                $vec::load_unaligned(&data[offset..])
+                $vec::from_slice_unaligned(&data[offset..])
             }
 
             #[inline(always)]
             unsafe fn load_unchecked(data: &[$el], offset: usize) -> $vec {
                 debug_assert!(data[offset..].len() >= Self::WIDTH);
-                $vec::load_unaligned_unchecked(&data[offset..])
+                $vec::from_slice_unaligned_unchecked(&data[offset..])
             }
 
             #[inline(always)]
             fn store(self, data: &mut [$el], offset: usize) {
-                $vec::store_unaligned(self, &mut data[offset..]);
+                $vec::write_to_slice_unaligned(self, &mut data[offset..]);
             }
 
             #[inline(always)]
             unsafe fn store_unchecked(self, data: &mut [$el], offset: usize) {
                 debug_assert!(data[offset..].len() >= Self::WIDTH);
-                $vec::store_unaligned_unchecked(self, &mut data[offset..]);
+                $vec::write_to_slice_unaligned_unchecked(self, &mut data[offset..]);
             }
 
             #[inline(always)]


### PR DESCRIPTION
Fix on latest nightly by switching from `std::simd` to [`packed_simd`](https://github.com/rust-lang-nursery/packed_simd).

Also fixes the trick being used to avoid having to switch between core/std per mod which was broken on latest nightly with `use crate::std::` not resolving.

Also fixes `#[no_std]` being set when the default `std` feature isn't passed, rather than when the recently-made-nonexistent `no-std` feature being passed.