### PR TITLE
Update packed_simd and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "faster"
 description = "Explicit SIMD for humans"
 authors = ["Adam Niederer <adam.niederer@gmail.com>"]
 license = "MPL-2.0"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2018"
 
 keywords = ["simd"]
@@ -14,7 +14,7 @@ readme = "README.org"
 
 [dependencies]
 vektor = "0.2.1"
-packed_simd = "0.3"
+packed_simd = {version = "0.3.4", package = "packed_simd_2"}
 
 [features]
 default = ["std"]


### PR DESCRIPTION
### From the `packed_simd` README.md:

The Crates.io Version Can No Longer Be Updated!

The original maintainer is out of contact, and the new maintainers (the Portable SIMD Project Group) do not have the appropriate crates.io permissions to issue updates.

We are aware that the version available on crates.io is currently broken, and will not build.

If you need to continue to use the crate, we have published a "next version" under an alternative name.

Adjust your `[dependencies]` section of `Cargo.toml` to be the following:
```toml
packed_simd = { version = "0.3.4", package = "packed_simd_2" }
```