### PR TITLE
Switch back to packed_simd dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.org"
 
 [dependencies]
 vektor = "0.2.1"
-packed_simd = {version = "0.3.4", package = "packed_simd_2"}
+packed_simd = "0.3.9"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
packed_simd is now again being published under its original name.